### PR TITLE
Fix ImportWorker

### DIFF
--- a/app/src/main/java/com/arslandaim/playtube/workers/ImportWorker.kt
+++ b/app/src/main/java/com/arslandaim/playtube/workers/ImportWorker.kt
@@ -24,6 +24,7 @@ import com.arslandaim.playtube.R
 import com.arslandaim.playtube.utils.PTLog
 import com.arslandaim.playtube.utils.VideoUtils
 import com.google.gson.Gson
+import com.google.gson.Strictness
 import com.google.gson.stream.JsonReader
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -76,7 +77,7 @@ class ImportWorker @AssistedInject constructor(
         
         var importedCount = 0
         var malformedCount = 0
-        val inputStream = getStreamForFile(uri, listOf("watch-history.json", "MyActivity.json")) 
+        val inputStream = getWatchHistoryStream(uri)
             ?: return Result.failure(Data.Builder().putString("error", context.getString(R.string.error_history_not_found)).build())
 
         inputStream.use { stream ->
@@ -147,7 +148,7 @@ class ImportWorker @AssistedInject constructor(
         updateProgress(0f, context.getString(R.string.loading))
         
         val channelIds = mutableListOf<String>()
-        val inputStream = getStreamForFile(uri, listOf("subscriptions.csv")) 
+        val inputStream = getSubscriptionsStream(uri) 
             ?: return Result.failure(Data.Builder().putString("error", context.getString(R.string.error_subscriptions_not_found)).build())
 
         inputStream.use { stream ->
@@ -207,40 +208,158 @@ class ImportWorker @AssistedInject constructor(
 
         return Result.success(Data.Builder().putInt(COUNT_KEY, importedCount).build())
     }
-
-    private fun getStreamForFile(uri: Uri, targetFileNames: List<String>): InputStream? {
+    
+    private fun getSubscriptionsStream(uri: Uri): InputStream? {
         val cr = context.contentResolver
         val type = cr.getType(uri)
-        val isZip = type == "application/zip" || 
-                    uri.path?.endsWith(".zip", ignoreCase = true) == true ||
-                    type == "application/x-zip-compressed"
+        val isZip = type == "application/zip" ||
+            uri.path?.endsWith(".zip", ignoreCase = true) == true ||
+            type == "application/x-zip-compressed"
 
         if (!isZip) {
-            // Check if the single file matches any of our targets
             val fileName = getFileName(uri) ?: ""
-            return if (targetFileNames.any { fileName.endsWith(it, ignoreCase = true) }) {
+            return if (fileName.endsWith("csv", ignoreCase = true)) {
                 cr.openInputStream(uri)
             } else {
                 null
             }
         }
 
-        // Search in ZIP
         return try {
-            val zipInputStream = ZipInputStream(cr.openInputStream(uri))
-            var entry = zipInputStream.nextEntry
+            val zip = ZipInputStream(cr.openInputStream(uri))
+            val byName = mutableListOf<String>()
+            val fallback = mutableListOf<String>()
+            var entry = zip.nextEntry
             while (entry != null) {
                 val name = entry.name
-                if (targetFileNames.any { name.endsWith(it, ignoreCase = true) }) {
-                    return zipInputStream
+                if (name.endsWith(".csv", ignoreCase = true)) {
+                    fallback.add(name)
+                    if (name.lowercase().contains("subscriptions")) {
+                        byName.add(name)
+                    }
                 }
-                zipInputStream.closeEntry()
-                entry = zipInputStream.nextEntry
+                zip.closeEntry()
+                entry = zip.nextEntry
             }
-            zipInputStream.close()
-            null
+            zip.close()
+
+            val chosen = byName.firstOrNull() ?: fallback.firstOrNull() ?: return null
+            openZipEntry(uri, chosen)
         } catch (e: Exception) {
             null
+        }
+    }
+
+    private fun getWatchHistoryStream(uri: Uri): InputStream? {
+        val cr = context.contentResolver
+        val type = cr.getType(uri)
+        val isZip = type == "application/zip" ||
+            uri.path?.endsWith(".zip", ignoreCase = true) == true ||
+            type == "application/x-zip-compressed"
+
+        if (!isZip) {
+            val fileName = getFileName(uri) ?: ""
+            return if (fileName.endsWith("json", ignoreCase = true)) {
+                cr.openInputStream(uri)
+            } else {
+                null
+            }
+        }
+
+        return try {
+            val zip = ZipInputStream(cr.openInputStream(uri))
+            val watchByName = mutableListOf<String>()
+            val watchByContent = mutableListOf<String>()
+            val jsonFallback = mutableListOf<String>()
+            var entry = zip.nextEntry
+            while (entry != null) {
+                val name = entry.name
+                if (name.endsWith(".json", ignoreCase = true)) {
+                    jsonFallback.add(name)
+                    if (isWatchHistoryFileName(name)) {
+                        watchByName.add(name)
+                    } else if (isWatchHistoryJson(zip)) {
+                        watchByContent.add(name)
+                    }
+                }
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
+            zip.close()
+
+            val chosen = watchByName.firstOrNull()
+                ?: watchByContent.firstOrNull()
+                ?: jsonFallback.firstOrNull()
+                ?: return null
+            openZipEntry(uri, chosen)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun openZipEntry(uri: Uri, entryName: String): ZipInputStream? {
+        val zip = try {
+            ZipInputStream(context.contentResolver.openInputStream(uri))
+        } catch (e: Exception) {
+            return null
+        }
+        var entry = zip.nextEntry
+        while (entry != null) {
+            if (entry.name == entryName) return zip
+            zip.closeEntry()
+            entry = zip.nextEntry
+        }
+        zip.close()
+        return null
+    }
+
+    private fun isWatchHistoryFileName(name: String): Boolean {
+        val lower = name.lowercase()
+        return lower.contains("watch-history") ||
+            (lower.contains("watch") && lower.contains("history"))
+    }
+
+    private fun isWatchHistoryJson(stream: InputStream): Boolean {
+        return try {
+            val reader = JsonReader(InputStreamReader(stream, "UTF-8"))
+            reader.strictness = Strictness.LENIENT
+            reader.beginArray()
+            var watchLike = 0
+            var searchLike = 0
+            var count = 0
+            while (reader.hasNext() && count < 30) {
+                reader.beginObject()
+                var hasSubtitles = false
+                var hasDescription = false
+                var hasDetails = false
+                while (reader.hasNext()) {
+                    when (reader.nextName()) {
+                        "subtitles" -> {
+                            hasSubtitles = true
+                            reader.skipValue()
+                        }
+                        "description" -> {
+                            hasDescription = true
+                            reader.skipValue()
+                        }
+                        "details" -> {
+                            hasDetails = true
+                            reader.skipValue()
+                        }
+                        else -> reader.skipValue()
+                    }
+                }
+                reader.endObject()
+                if (hasSubtitles && !hasDescription && !hasDetails) {
+                    watchLike++
+                } else if (hasDescription || hasDetails) {
+                    searchLike++
+                }
+                count++
+            }
+            watchLike >= searchLike && watchLike > 0
+        } catch (e: Exception) {
+            false
         }
     }
 


### PR DESCRIPTION
# Importing Takeout data (ZIP / individual files) — fix for localized file names

> Fixes issue: [#28 — "import my subscription or history watch issue"](https://github.com/lau-luna/PlayTube/issues/28)

## Problem

The import logic relied on **hardcoded English file names**. The original `importHistory()` and `importSubscriptions()` matched files exclusively by these names:

```kotlin
getStreamForFile(uri, listOf("watch-history.json", "MyActivity.json"))  // history
getStreamForFile(uri, listOf("subscriptions.csv"))                      // subscriptions
```

However, Google Takeout **localizes the exported file names based on the account language**, so they don't always match those hardcoded names.

For example, with a Google account in Spanish, Takeout exports:

```
Takeout/
└── YouTube y YouTube Music
    ├── historial de videos
    │   ├── historial de búsquedas.json
    │   └── historial de reproducciones.json
    └── suscripciones
        └── suscripciones.csv
```

As a result, the import **failed** (files not found) or, when importing a **ZIP**, `getStreamForFile` returned the first file matching the extension — which could end up importing the **search history** (`historial de búsquedas.json`) instead of the **watch history** (`historial de reproducciones.json`).

## Changes

Only **one file** was modified:

- `app/src/main/java/com/arslandaim/playtube/workers/ImportWorker.kt`

### 1. `importHistory()` — filename matching replaced with smart detection

Before:

```kotlin
val inputStream = getStreamForFile(uri, listOf("watch-history.json", "MyActivity.json"))
```

After:

```kotlin
val inputStream = getWatchHistoryStream(uri)
```

### 2. `importSubscriptions()` — filename matching replaced with name preference + fallback

Before:

```kotlin
val inputStream = getStreamForFile(uri, listOf("subscriptions.csv"))
```

After:

```kotlin
val inputStream = getSubscriptionsStream(uri)
```

### 3. Old `getStreamForFile` removed, new methods added

| Method | What it does |
|---|---|
| `getWatchHistoryStream(uri)` | Watch-history selection. Standalone `.json` → returned directly; ZIP → finds the correct JSON and opens it. |
| `getSubscriptionsStream(uri)` | Subscriptions selection. Standalone `.csv` → returned directly; ZIP → prefers a `subscriptions.csv`-named entry, falls back to the first `.csv`. |
| `openZipEntry(uri, entryName)` | Re-opens the ZIP and seeks to the chosen entry, returning its `InputStream`. |
| `isWatchHistoryFileName(name)` | Fast filename-based detection (`watch-history.json`, or containing `watch` + `history`). |
| `isWatchHistoryJson(stream)` | Content-based detection (language-independent), sampling up to 30 items and applying majority rule. |

The old `getStreamForFile(uri, targetFileNames)` method was removed.

### 4. How the watch-history file inside the ZIP is chosen

Priority order:

1. **By name**: if a `watch-history.json`-style file exists, use it.
2. **By content**: if no name matches, inspect each `.json` and classify it by its structure.
3. **Fallback**: if nothing found, use the first `.json`.

### 5. Content-based classification (language-independent)

Google localizes the JSON *text* but **not the field names** (always English). That's what allows distinguishing the files by structure:

- **Watch history** → items have `subtitles` (the channel) and no `description` / `details`.
- **Search history** → items have no `subtitles` and do have `description` and/or `details`.

Real example of **watch history** (has `subtitles`, no `details`):

```json
{
  "title": "Has visto Penpals - PENPALS (1997.07.20) [Full Album]",
  "titleUrl": "https://www.youtube.com/watch?v=h8KmybW-_hg",
  "subtitles": [{ "name": "GreatLee", "url": "..." }],
  "time": "2026-09-05T02:03:29.999Z"
}
```

Real example of **search history** (has `description` and `details`, no `subtitles`):

```json
{
  "title": "Has visto C01ILDV...",
  "titleUrl": "https://www.youtube.com/watch?v=qR0w7bP9jBM",
  "description": "Visto a las 1:08 a.m.",
  "time": "2026-09-05T01:08:06.388Z",
  "details": [{ "name": "De los anuncios de Google" }]
}
```


## Gradle tests

Output of `./gradlew test`:

````
(base) 󰣇 side_projects/kotlin/PlayTube   main  !+? ❯ ./gradlew test --rerun-tasks
Reusing configuration cache.

> Task :app:kspDebugKotlin
w: [ksp] /home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/local/PlayTubeDatabase.kt:31: Schema export directory was not provided to the annotation processor so Room cannot export the schema. You can either provide `room.schemaLocation` annotation processor argument by applying the Room Gradle plugin (id 'androidx.room') OR set exportSchema to false.

> Task :app:compileDebugKotlin
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/MainActivity.kt:98:12 Annotation 'androidx.media3.common.util.UnstableApi' is not annotated with '@RequiresOptIn'. '@OptIn' has no effect.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/network/ParallelDownloader.kt:136:42 Elvis operator (?:) always returns the left operand of non-nullable type 'ResponseBody'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/network/ParallelDownloader.kt:181:101 Unnecessary safe call on a non-null receiver of type 'ResponseBody'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/network/YouTubeDownloader.kt:84:41 Unnecessary safe call on a non-null receiver of type 'ResponseBody'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/network/potoken/PoTokenGenerator.kt:85:77 'fun resume(value: Unit, onCancellation: ((Throwable) -> Unit)?): Unit' is deprecated. Use the overload that also accepts the `value` and the coroutine context in lambda.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/network/potoken/PoTokenGenerator.kt:92:73 'fun resume(value: Unit, onCancellation: ((Throwable) -> Unit)?): Unit' is deprecated. Use the overload that also accepts the `value` and the coroutine context in lambda.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/SearchRepositoryImpl.kt:79:59 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/SearchRepositoryImpl.kt:87:63 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/SearchRepositoryImpl.kt:150:59 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/SearchRepositoryImpl.kt:158:63 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/SearchRepositoryImpl.kt:188:56 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:97:59 'val url: String?' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:119:46 Elvis operator (?:) always returns the left operand of non-nullable type 'String'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:120:55 'val url: String?' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:123:46 Elvis operator (?:) always returns the left operand of non-nullable type 'String'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:124:55 'val url: String?' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:134:33 'val url: String?' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:140:35 'val url: String?' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:173:109 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:173:161 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:187:42 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:187:94 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:205:143 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:205:200 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:211:139 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:211:192 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:265:272 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:273:219 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:273:274 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/data/repository/VideoRepositoryImpl.kt:333:54 Unnecessary safe call on a non-null receiver of type '(Mutable)List<Image!>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/components/VideoItemComponents.kt:308:57 'val Icons.Filled.PlaylistPlay: ImageVector' is deprecated. Use the AutoMirrored version at Icons.AutoMirrored.Filled.PlaylistPlay.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:52:44 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:53:46 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:54:40 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:113:44 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:135:57 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:207:48 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:208:52 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:218:54 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:225:56 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:246:47 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:271:48 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:296:46 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:297:48 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:298:52 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/navigation/NavGraph.kt:339:50 'fun <reified VM : ViewModel> hiltViewModel(viewModelStoreOwner: ViewModelStoreOwner = ..., key: String? = ...): VM' is deprecated. Moved to package: androidx.hilt.lifecycle.viewmodel.compose.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/player/PlayerScreen.kt:1019:61 No cast needed.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/player/PlayerScreen.kt:1080:47 Check for instance is always 'false'. This will become an error in language version 2.4. See https://youtrack.jetbrains.com/issue/KTLC-365.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/player/PlayerViewModel.kt:842:236 Elvis operator (?:) always returns the left operand of non-nullable type 'Long'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/search/SearchViewModel.kt:128:21 'when' is exhaustive so 'else' is redundant here.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/settings/SettingsScreen.kt:245:48 'fun largeTopAppBarColors(containerColor: Color = ..., scrolledContainerColor: Color = ..., navigationIconContentColor: Color = ..., titleContentColor: Color = ..., actionIconContentColor: Color = ...): TopAppBarColors' is deprecated. Use topAppBarColors instead.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/subscriptions/SubscriptionsFeedViewModel.kt:70:28 Unchecked cast of 'Any?' to 'List<SubscriptionEntity>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/screens/subscriptions/SubscriptionsFeedViewModel.kt:74:31 Unchecked cast of 'Any?' to 'List<HistoryEntity>'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/theme/Theme.kt:73:20 'var statusBarColor: Int' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/ui/theme/Theme.kt:74:20 'var navigationBarColor: Int' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/utils/ConnectivityObserver.kt:72:38 'val allNetworks: Array<(out) Network!>' is deprecated. Deprecated in Java.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:90:32 Unnecessary safe call on a non-null receiver of type 'DownloadEntity'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:91:47 Unnecessary non-null assertion (!!) on a non-null receiver of type 'String'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:103:28 Unnecessary non-null assertion (!!) on a non-null receiver of type 'String'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:468:29 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:474:30 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:474:91 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:476:36 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:476:44 Elvis operator (?:) always returns the left operand of non-nullable type 'ResponseBody'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:587:29 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:589:29 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:595:30 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:595:97 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:597:36 Unnecessary non-null assertion (!!) on a non-null receiver of type 'Response'.
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/main/java/com/arslandaim/playtube/workers/DownloadWorker.kt:597:44 Elvis operator (?:) always returns the left operand of non-nullable type 'ResponseBody'.

> Task :app:compileDebugUnitTestKotlin
w: file:///home/lau/Projects/side_projects/kotlin/PlayTube/app/src/test/java/com/arslandaim/playtube/data/network/IPv4OnlyDnsTest.kt:28:20 Check for instance is always 'true'.
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

[Incubating] Problems report is available at: file:///home/lau/Projects/side_projects/kotlin/PlayTube/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 27s
33 actionable tasks: 33 executed
Configuration cache entry reused.
````

## APK build and phone testing

Built the debug APK with `./gradlew assembleDebug` and tested it on my phone:

- **Build**: APK generated at `app/build/outputs/apk/debug/app-debug.apk` ✅
- **Phone test**: imported the Takeout ZIP (and individual `.json` / `.csv` files) and the app correctly picked up the watch history ✅

Screenshots:
<img width="702" height="1599" alt="watch-history-1" src="https://github.com/user-attachments/assets/40d3234c-9192-4915-97d8-6d5855ad69e2" />
<img width="702" height="1599" alt="subscriptions-1" src="https://github.com/user-attachments/assets/bfc37c8a-93ed-455d-b3c4-29c7cad76229" />
<img width="702" height="1599" alt="watch-history-2" src="https://github.com/user-attachments/assets/2b9dcb15-d4f2-451b-9bbb-6087f4bfbc28" />
<img width="702" height="1599" alt="subscriptions-2" src="https://github.com/user-attachments/assets/0840b720-03c8-452e-9993-9d13cd586c89" />

